### PR TITLE
Replace has_git by test_requires_git

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,6 +1,7 @@
 requires 'perl', '5.008001';
 requires 'Git::Repository', '1.13';
 requires 'Git::Repository::Plugin::Log';
+requires 'Test::Requires::Git', '1.005';
 
 on 'test' => sub {
     requires 'Test::Fatal';

--- a/t/00_basic.t
+++ b/t/00_basic.t
@@ -3,9 +3,9 @@ use warnings;
 
 use Test::More;
 use Test::Fatal qw(exception);
-use Test::Git qw(has_git);
+use Test::Requires::Git;
 
-has_git();
+test_requires_git();
 plan tests => 2;
 
 my $package = 'Git::Repository::Plugin::Gerrit';


### PR DESCRIPTION
Test::Git::has_git is obsolete and replaced by
Test::Requires::Git::test_requires_git.
